### PR TITLE
Avalon Fingerprint

### DIFF
--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -9,7 +9,6 @@ import rdkit.Chem.rdFingerprintGenerator as fpgens
 from e3fp.conformer.generate import (
     FORCEFIELD_DEF,
     MAX_ENERGY_DIFF_DEF,
-    NUM_CONF_DEF,
     POOL_MULTIPLIER_DEF,
     RMSD_CUTOFF_DEF,
 )
@@ -18,6 +17,7 @@ from e3fp.pipeline import fprints_from_mol
 from joblib import cpu_count
 from ogb.graphproppred import GraphPropPredDataset
 from rdkit import Chem
+from rdkit.Avalon.pyAvalonTools import GetAvalonCountFP, GetAvalonFP
 from rdkit.Chem import MolFromSmiles
 from rdkit.Chem.PropertyMol import PropertyMol
 from rdkit.Chem.rdMolDescriptors import GetMACCSKeysFingerprint
@@ -27,6 +27,7 @@ from skfp import (
     ECFP,
     MHFP,
     AtomPairFingerprint,
+    AvalonFingerprint,
     ERGFingerprint,
     MACCSKeysFingerprint,
     MAP4Fingerprint,
@@ -425,6 +426,21 @@ if __name__ == "__main__":
     MHFP_sequential_times = get_all_sequential_times(X, get_mhfp)
     save_all_results(
         MHFP_skfp_times, MHFP_sequential_times, n_molecules, "MHFP", True
+    )
+
+    # Avalon FINGERPRINT
+    print("Avalon")
+    Avalon_skfp_times_count = get_all_times_skfp(X, AvalonFingerprint, True)
+    Avalon_sequential_times = [
+        get_all_sequential_times(X, GetAvalonFP, False),
+        get_all_sequential_times(X, GetAvalonCountFP, False),
+    ]
+    save_all_results(
+        Avalon_skfp_times_count,
+        Avalon_sequential_times,
+        n_molecules,
+        "ErG fingerprint",
+        False,
     )
 
     # E3FP_skfp_times = get_all_times_skfp(X, E3FP, False)

--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -439,7 +439,7 @@ if __name__ == "__main__":
         Avalon_skfp_times_count,
         Avalon_sequential_times,
         n_molecules,
-        "ErG fingerprint",
+        "Avalon Fingerprint",
         False,
     )
 

--- a/skfp/__init__.py
+++ b/skfp/__init__.py
@@ -1,4 +1,5 @@
 from skfp.fingerprints.atom_pair import AtomPairFingerprint
+from skfp.fingerprints.avalon import AvalonFingerprint
 from skfp.fingerprints.e3fp import E3FP
 from skfp.fingerprints.ecfp import ECFP
 from skfp.fingerprints.erg import ERGFingerprint

--- a/skfp/fingerprints/avalon.py
+++ b/skfp/fingerprints/avalon.py
@@ -1,0 +1,66 @@
+from typing import List, Optional, Union
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as spsparse
+
+from skfp.fingerprints.base import FingerprintTransformer
+
+
+class AvalonFingerprint(FingerprintTransformer):
+    def __init__(
+        self,
+        nBits=512,
+        isQuery: bool = False,
+        bitFlags: int = 15761407,
+        resetVect: bool = False,
+        sparse: bool = False,
+        n_jobs: int = None,
+        verbose: int = 0,
+        random_state: int = 0,
+        count: bool = False,
+    ):
+        super().__init__(
+            n_jobs=n_jobs,
+            sparse=sparse,
+            verbose=verbose,
+            random_state=random_state,
+            count=count,
+        )
+        self.nBits = nBits
+        self.isQuery = isQuery
+        self.bitFlags = bitFlags
+        self.resetVect = resetVect
+
+    def _calculate_fingerprint(
+        self, X: Union[pd.DataFrame, np.ndarray, list[str]]
+    ) -> Union[np.ndarray, spsparse.csr_array]:
+        X = self._validate_input(X)
+        from rdkit.Avalon.pyAvalonTools import GetAvalonCountFP, GetAvalonFP
+
+        if self.count:
+            X = [
+                GetAvalonCountFP(
+                    x,
+                    nBits=self.nBits,
+                    isQuery=self.isQuery,
+                    bitFlags=self.bitFlags,
+                ).ToList()  # should be sparse or numpy
+                for x in X
+            ]
+        else:
+            X = [
+                GetAvalonFP(
+                    x,
+                    nBits=self.nBits,
+                    isQuery=self.isQuery,
+                    bitFlags=self.bitFlags,
+                    resetVect=self.resetVect,
+                )
+                for x in X
+            ]
+
+        if self.sparse:
+            return spsparse.csr_array(X)
+        else:
+            return np.array(X)

--- a/skfp/fingerprints/avalon.py
+++ b/skfp/fingerprints/avalon.py
@@ -10,10 +10,10 @@ from skfp.fingerprints.base import FingerprintTransformer
 class AvalonFingerprint(FingerprintTransformer):
     def __init__(
         self,
-        nBits=512,
-        isQuery: bool = False,
-        bitFlags: int = 15761407,
-        resetVect: bool = False,
+        n_bits: int = 512,
+        is_query: bool = False,
+        bit_flags: int = 15761407,
+        reset_vect: bool = False,
         sparse: bool = False,
         n_jobs: int = None,
         verbose: int = 0,
@@ -27,10 +27,10 @@ class AvalonFingerprint(FingerprintTransformer):
             random_state=random_state,
             count=count,
         )
-        self.nBits = nBits
-        self.isQuery = isQuery
-        self.bitFlags = bitFlags
-        self.resetVect = resetVect
+        self.n_bits = n_bits
+        self.is_query = is_query
+        self.bit_flags = bit_flags
+        self.reset_vect = reset_vect
 
     def _calculate_fingerprint(
         self, X: Union[pd.DataFrame, np.ndarray, list[str]]
@@ -42,9 +42,9 @@ class AvalonFingerprint(FingerprintTransformer):
             X = [
                 GetAvalonCountFP(
                     x,
-                    nBits=self.nBits,
-                    isQuery=self.isQuery,
-                    bitFlags=self.bitFlags,
+                    nBits=self.n_bits,
+                    isQuery=self.is_query,
+                    bitFlags=self.bit_flags,
                 ).ToList()  # should be sparse or numpy
                 for x in X
             ]
@@ -52,10 +52,10 @@ class AvalonFingerprint(FingerprintTransformer):
             X = [
                 GetAvalonFP(
                     x,
-                    nBits=self.nBits,
-                    isQuery=self.isQuery,
-                    bitFlags=self.bitFlags,
-                    resetVect=self.resetVect,
+                    nBits=self.n_bits,
+                    isQuery=self.is_query,
+                    bitFlags=self.bit_flags,
+                    resetVect=self.reset_vect,
                 )
                 for x in X
             ]

--- a/tests/fingerprints_tests.py
+++ b/tests/fingerprints_tests.py
@@ -15,15 +15,17 @@ from ogb.graphproppred import GraphPropPredDataset
 from rdkit import Chem
 
 # from rdkit.Chem.PropertyMol import PropertyMol
+from rdkit.Avalon.pyAvalonTools import GetAvalonCountFP, GetAvalonFP
 from rdkit.Chem.rdMolDescriptors import GetMACCSKeysFingerprint
 from rdkit.Chem.rdReducedGraphs import GetErGFingerprint
 from scipy.sparse import csr_array, vstack
 
-from skfp import (  # E3FP,
+from skfp import ERGFingerprint  # E3FP,
+from skfp import (
     ECFP,
     MHFP,
     AtomPairFingerprint,
-    ERGFingerprint,
+    AvalonFingerprint,
     MACCSKeysFingerprint,
     MAP4Fingerprint,
     RDKitFingerprint,
@@ -398,6 +400,50 @@ def test_mhfp_sparse_count_fingerprint(
     mhfp = MHFP(random_state=0, n_jobs=-1, sparse=True, count=True)
     X_emf = mhfp.transform(X)
     X_rdkit = csr_array([get_mhfp(x, count=True) for x in X_for_rdkit])
+    if not np.all(X_emf.toarray() == X_rdkit.toarray()):
+        raise AssertionError
+
+
+def test_avalon_fingerprint(example_molecules, rdkit_example_molecules):
+    X = example_molecules
+    X_for_rdkit = rdkit_example_molecules
+    fp_transformer = AvalonFingerprint(random_state=0, n_jobs=-1)
+    X_emf = fp_transformer.transform(X)
+    X_rdkit = np.stack([GetAvalonFP(x) for x in X_for_rdkit])
+    if not np.all(X_emf == X_rdkit):
+        raise AssertionError
+
+
+def test_avalon_sparse_fingerprint(example_molecules, rdkit_example_molecules):
+    X = example_molecules
+    X_for_rdkit = rdkit_example_molecules
+    fp_transformer = AvalonFingerprint(sparse=True, random_state=0, n_jobs=-1)
+    X_emf = fp_transformer.transform(X)
+    X_rdkit = vstack([csr_array(GetAvalonFP(x)) for x in X_for_rdkit])
+    if not np.all(X_emf.toarray() == X_rdkit.toarray()):
+        raise AssertionError
+
+
+def test_avalon_count_fingerprint(example_molecules, rdkit_example_molecules):
+    X = example_molecules
+    X_for_rdkit = rdkit_example_molecules
+    fp_transformer = AvalonFingerprint(count=True, random_state=0, n_jobs=-1)
+    X_emf = fp_transformer.transform(X)
+    X_rdkit = np.stack([GetAvalonCountFP(x).ToList() for x in X_for_rdkit])
+    if not np.all(X_emf == X_rdkit):
+        raise AssertionError
+
+
+def test_avalon_sparse_count_fingerprint(
+    example_molecules, rdkit_example_molecules
+):
+    X = example_molecules
+    X_for_rdkit = rdkit_example_molecules
+    fp_transformer = AvalonFingerprint(
+        sparse=True, count=True, random_state=0, n_jobs=-1
+    )
+    X_emf = fp_transformer.transform(X)
+    X_rdkit = vstack([csr_array(GetAvalonCountFP(x)) for x in X_for_rdkit])
     if not np.all(X_emf.toarray() == X_rdkit.toarray()):
         raise AssertionError
 

--- a/tests/fingerprints_tests.py
+++ b/tests/fingerprints_tests.py
@@ -443,7 +443,9 @@ def test_avalon_sparse_count_fingerprint(
         sparse=True, count=True, random_state=0, n_jobs=-1
     )
     X_emf = fp_transformer.transform(X)
-    X_rdkit = vstack([csr_array(GetAvalonCountFP(x)) for x in X_for_rdkit])
+    X_rdkit = vstack(
+        [csr_array(GetAvalonCountFP(x).ToList()) for x in X_for_rdkit]
+    )
     if not np.all(X_emf.toarray() == X_rdkit.toarray()):
         raise AssertionError
 


### PR DESCRIPTION
RDKit's SparseIntVector cannot be directly converted to numpy or sparse array, therefore it forces our implementation to calculate a 2d python list that then gets converted to either sparse or numpy array. This could be considered suboptimal.