### PR TITLE
e-state fingerprint

### DIFF
--- a/benchmarking/benchmark.py
+++ b/benchmarking/benchmark.py
@@ -19,6 +19,7 @@ from ogb.graphproppred import GraphPropPredDataset
 from rdkit import Chem
 from rdkit.Avalon.pyAvalonTools import GetAvalonCountFP, GetAvalonFP
 from rdkit.Chem import MolFromSmiles
+from rdkit.Chem.EState.Fingerprinter import FingerprintMol
 from rdkit.Chem.PropertyMol import PropertyMol
 from rdkit.Chem.rdMolDescriptors import GetMACCSKeysFingerprint
 from rdkit.Chem.rdReducedGraphs import GetErGFingerprint
@@ -29,6 +30,7 @@ from skfp import (
     AtomPairFingerprint,
     AvalonFingerprint,
     ERGFingerprint,
+    EStateFingerprint,
     MACCSKeysFingerprint,
     MAP4Fingerprint,
     RDKitFingerprint,
@@ -440,6 +442,20 @@ if __name__ == "__main__":
         Avalon_sequential_times,
         n_molecules,
         "Avalon Fingerprint",
+        False,
+    )
+
+    # EState FINGERPRINT
+    print("EState")
+    EState_skfp_times_count = get_all_times_skfp(X, EStateFingerprint, False)
+    EState_sequential_times = get_all_sequential_times(
+        X, FingerprintMol, False
+    )
+    save_all_results(
+        EState_skfp_times_count,
+        EState_sequential_times,
+        n_molecules,
+        "EState Fingerprint",
         False,
     )
 

--- a/skfp/__init__.py
+++ b/skfp/__init__.py
@@ -1,6 +1,7 @@
 from skfp.fingerprints.atom_pair import AtomPairFingerprint
 from skfp.fingerprints.avalon import AvalonFingerprint
 from skfp.fingerprints.e3fp import E3FP
+from skfp.fingerprints.e_state import EStateFingerprint
 from skfp.fingerprints.ecfp import ECFP
 from skfp.fingerprints.erg import ERGFingerprint
 from skfp.fingerprints.maccs_keys import MACCSKeysFingerprint

--- a/skfp/fingerprints/e_state.py
+++ b/skfp/fingerprints/e_state.py
@@ -1,0 +1,48 @@
+from typing import Union
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as spsparse
+
+from skfp.fingerprints.base import FingerprintTransformer
+
+
+class EStateFingerprint(FingerprintTransformer):
+    """this fingerprint returns 2 arrays:
+    The first (of ints) contains the number of times each possible atom type is hit
+     The second (of floats) contains the sum of the EState indices for atoms of
+    """
+
+    def __init__(
+        self,
+        sparse: bool = False,
+        n_jobs: int = None,
+        verbose: int = 0,
+        random_state: int = 0,
+        count: bool = False,
+    ):
+        super().__init__(
+            n_jobs=n_jobs,
+            sparse=sparse,
+            verbose=verbose,
+            random_state=random_state,
+            count=count,
+        )
+
+    def _calculate_fingerprint(
+        self, X: Union[pd.DataFrame, np.ndarray, list[str]]
+    ) -> Union[np.ndarray, spsparse.csr_array]:
+        X = self._validate_input(X)
+        from rdkit.Chem.EState.Fingerprinter import FingerprintMol
+
+        X = np.array([FingerprintMol(x) for x in X])
+        X = np.concatenate([X[:, 0], X[:, 1]], axis=1)
+
+        if self.sparse:
+            return spsparse.csr_array(X)
+        else:
+            return X
+
+    def transform(self, X: Union[pd.DataFrame, np.ndarray, list[str]]):
+        X = super().transform(X)
+        return X[:, :79], X[:, 79:]

--- a/tests/fingerprints_tests.py
+++ b/tests/fingerprints_tests.py
@@ -452,29 +452,75 @@ def test_avalon_sparse_count_fingerprint(
         raise AssertionError
 
 
-def test_estate_fingerprint(example_molecules, rdkit_example_molecules):
+def test_estate_sum_fingerprint(example_molecules, rdkit_example_molecules):
     X = example_molecules
     X_for_rdkit = rdkit_example_molecules
     estate = EStateFingerprint(n_jobs=-1, sparse=False)
     X_emf = estate.transform(X)
-    X_rdkit = np.array([FingerprintMol(x) for x in X_for_rdkit])
-    X_rdkit = (X_rdkit[:, 0], X_rdkit[:, 1])
-    if not np.all(X_emf[0] == X_rdkit[0]):
-        raise AssertionError
-    if not np.all(X_emf[1] == X_rdkit[1]):
+    X_rdkit = np.array([FingerprintMol(x) for x in X_for_rdkit])[:, 1]
+    if not np.all(X_emf == X_rdkit):
         raise AssertionError
 
 
-def test_estate_sparse_fingerprint(example_molecules, rdkit_example_molecules):
+def test_estate_count_fingerprint(example_molecules, rdkit_example_molecules):
+    X = example_molecules
+    X_for_rdkit = rdkit_example_molecules
+    estate = EStateFingerprint(n_jobs=-1, variant="count")
+    X_emf = estate.transform(X)
+    X_rdkit = np.array([FingerprintMol(x) for x in X_for_rdkit])[:, 0]
+    if not np.all(X_emf == X_rdkit):
+        raise AssertionError
+
+
+def test_estate_binary_fingerprint(example_molecules, rdkit_example_molecules):
+    X = example_molecules
+    X_for_rdkit = rdkit_example_molecules
+    estate = EStateFingerprint(n_jobs=-1, variant="binary")
+    X_emf = estate.transform(X)
+    X_rdkit = np.array([FingerprintMol(x) for x in X_for_rdkit])[:, 0] > 0
+    if not np.all(X_emf == X_rdkit):
+        raise AssertionError
+
+
+def test_estate_sparse_sum_fingerprint(
+    example_molecules, rdkit_example_molecules
+):
     X = example_molecules
     X_for_rdkit = rdkit_example_molecules
     estate = EStateFingerprint(n_jobs=-1, sparse=True)
     X_emf = estate.transform(X)
-    X_rdkit = np.array([FingerprintMol(x) for x in X_for_rdkit])
-    X_rdkit = (csr_array(X_rdkit[:, 0]), csr_array(X_rdkit[:, 1]))
-    if not np.all(X_emf[0].toarray() == X_rdkit[0].toarray()):
+    X_rdkit = csr_array(
+        np.array([FingerprintMol(x) for x in X_for_rdkit])[:, 1]
+    )
+    if not np.all(X_emf.toarray() == X_rdkit.toarray()):
         raise AssertionError
-    if not np.all(X_emf[1].toarray() == X_rdkit[1].toarray()):
+
+
+def test_estate_sparse_count_fingerprint(
+    example_molecules, rdkit_example_molecules
+):
+    X = example_molecules
+    X_for_rdkit = rdkit_example_molecules
+    estate = EStateFingerprint(n_jobs=-1, sparse=True, variant="count")
+    X_emf = estate.transform(X)
+    X_rdkit = csr_array(
+        np.array([FingerprintMol(x) for x in X_for_rdkit])[:, 0]
+    )
+    if not np.all(X_emf.toarray() == X_rdkit.toarray()):
+        raise AssertionError
+
+
+def test_estate_sparse_binary_fingerprint(
+    example_molecules, rdkit_example_molecules
+):
+    X = example_molecules
+    X_for_rdkit = rdkit_example_molecules
+    estate = EStateFingerprint(n_jobs=-1, sparse=True, variant="binary")
+    X_emf = estate.transform(X)
+    X_rdkit = csr_array(
+        np.array([FingerprintMol(x) for x in X_for_rdkit])[:, 0] > 0
+    )
+    if not np.all(X_emf.toarray() == X_rdkit.toarray()):
         raise AssertionError
 
 

--- a/tests/fingerprints_tests.py
+++ b/tests/fingerprints_tests.py
@@ -465,7 +465,7 @@ def test_estate_sum_fingerprint(example_molecules, rdkit_example_molecules):
 def test_estate_count_fingerprint(example_molecules, rdkit_example_molecules):
     X = example_molecules
     X_for_rdkit = rdkit_example_molecules
-    estate = EStateFingerprint(n_jobs=-1, variant="count")
+    estate = EStateFingerprint(n_jobs=-1, variant="binary", count=True)
     X_emf = estate.transform(X)
     X_rdkit = np.array([FingerprintMol(x) for x in X_for_rdkit])[:, 0]
     if not np.all(X_emf == X_rdkit):
@@ -501,7 +501,9 @@ def test_estate_sparse_count_fingerprint(
 ):
     X = example_molecules
     X_for_rdkit = rdkit_example_molecules
-    estate = EStateFingerprint(n_jobs=-1, sparse=True, variant="count")
+    estate = EStateFingerprint(
+        n_jobs=-1, sparse=True, variant="binary", count=True
+    )
     X_emf = estate.transform(X)
     X_rdkit = csr_array(
         np.array([FingerprintMol(x) for x in X_for_rdkit])[:, 0]

--- a/tests/fingerprints_tests.py
+++ b/tests/fingerprints_tests.py
@@ -16,6 +16,7 @@ from rdkit import Chem
 
 # from rdkit.Chem.PropertyMol import PropertyMol
 from rdkit.Avalon.pyAvalonTools import GetAvalonCountFP, GetAvalonFP
+from rdkit.Chem.EState.Fingerprinter import FingerprintMol
 from rdkit.Chem.rdMolDescriptors import GetMACCSKeysFingerprint
 from rdkit.Chem.rdReducedGraphs import GetErGFingerprint
 from scipy.sparse import csr_array, vstack
@@ -26,6 +27,7 @@ from skfp import (
     MHFP,
     AtomPairFingerprint,
     AvalonFingerprint,
+    EStateFingerprint,
     MACCSKeysFingerprint,
     MAP4Fingerprint,
     RDKitFingerprint,
@@ -276,8 +278,8 @@ def test_topological_torsion_sparse_count_fingerprint(
 def test_maccs_keys_fingerprint(example_molecules, rdkit_example_molecules):
     X = example_molecules
     X_for_rdkit = rdkit_example_molecules
-    erg = MACCSKeysFingerprint(n_jobs=-1, sparse=False)
-    X_emf = erg.transform(X)
+    maccs_keys = MACCSKeysFingerprint(n_jobs=-1, sparse=False)
+    X_emf = maccs_keys.transform(X)
     X_rdkit = np.array([GetMACCSKeysFingerprint(x) for x in X_for_rdkit])
 
     if not np.all(X_emf == X_rdkit):
@@ -289,8 +291,8 @@ def test_maccs_keys_sparse_fingerprint(
 ):
     X = example_molecules
     X_for_rdkit = rdkit_example_molecules
-    erg = MACCSKeysFingerprint(n_jobs=-1, sparse=True)
-    X_emf = erg.transform(X)
+    maccs_keys = MACCSKeysFingerprint(n_jobs=-1, sparse=True)
+    X_emf = maccs_keys.transform(X)
     X_rdkit = csr_array([GetMACCSKeysFingerprint(x) for x in X_for_rdkit])
     if not np.all(X_emf.toarray() == X_rdkit.toarray()):
         raise AssertionError
@@ -447,6 +449,32 @@ def test_avalon_sparse_count_fingerprint(
         [csr_array(GetAvalonCountFP(x).ToList()) for x in X_for_rdkit]
     )
     if not np.all(X_emf.toarray() == X_rdkit.toarray()):
+        raise AssertionError
+
+
+def test_estate_fingerprint(example_molecules, rdkit_example_molecules):
+    X = example_molecules
+    X_for_rdkit = rdkit_example_molecules
+    estate = EStateFingerprint(n_jobs=-1, sparse=False)
+    X_emf = estate.transform(X)
+    X_rdkit = np.array([FingerprintMol(x) for x in X_for_rdkit])
+    X_rdkit = (X_rdkit[:, 0], X_rdkit[:, 1])
+    if not np.all(X_emf[0] == X_rdkit[0]):
+        raise AssertionError
+    if not np.all(X_emf[1] == X_rdkit[1]):
+        raise AssertionError
+
+
+def test_estate_sparse_fingerprint(example_molecules, rdkit_example_molecules):
+    X = example_molecules
+    X_for_rdkit = rdkit_example_molecules
+    estate = EStateFingerprint(n_jobs=-1, sparse=True)
+    X_emf = estate.transform(X)
+    X_rdkit = np.array([FingerprintMol(x) for x in X_for_rdkit])
+    X_rdkit = (csr_array(X_rdkit[:, 0]), csr_array(X_rdkit[:, 1]))
+    if not np.all(X_emf[0].toarray() == X_rdkit[0].toarray()):
+        raise AssertionError
+    if not np.all(X_emf[1].toarray() == X_rdkit[1].toarray()):
         raise AssertionError
 
 


### PR DESCRIPTION
EState fingerprint functionality.

Please note that the fingerprint returns 2 arrays. This is how it was implemented in RDKit.
Each fingerprint is returned as a Python tuple of 2 NumPy arrays of the same size. Maybe could concatenate them instead, or specify return type as "count", "sum" or "both"?